### PR TITLE
FrontとFastAPIを繋いで動くようにする

### DIFF
--- a/front/script.js
+++ b/front/script.js
@@ -1,5 +1,5 @@
 async function praise() {
-  // TODO GET
+  // GET
   const response = await fetch("http://localhost:8000/home");
   const json = await response.json();
   const home = JSON.stringify(json);
@@ -24,13 +24,19 @@ function showPraiseForm() {
   document.getElementById("praiseFormContainer").classList.add("show");
 }
 
-function sendPraise() {
+async function sendPraise() {
   const praiseText = document.getElementById("praiseInput").value;
 
-  // TODO POST
-  // 確認用仮
   if (praiseText.trim() !== "") {
+    // POST
     alert("あなたの褒め言葉: " + praiseText);
+    const response = await fetch("http://localhost:8000/home", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sentence: praiseText }),
+    });
   }
 }
 

--- a/front/script.js
+++ b/front/script.js
@@ -1,6 +1,9 @@
-function praise() {
+async function praise() {
   // TODO GET
-  document.getElementById("praiseMessage").innerText = "えらいね";
+  const response = await fetch("http://localhost:8000/home");
+  const json = await response.json();
+  const home = JSON.stringify(json);
+  document.getElementById("praiseMessage").innerText = home.sentence;
 
   document.body.style.background = "white";
   document.getElementById("initialMessage").classList.add("hidden");

--- a/front/script.js
+++ b/front/script.js
@@ -32,9 +32,7 @@ async function sendPraise() {
     alert("あなたの褒め言葉: " + praiseText);
     const response = await fetch("http://localhost:8000/home", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+
       body: JSON.stringify({ sentence: praiseText }),
     });
   }

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 from fastapi import Body, FastAPI
+from fastapi.staticfiles import StaticFiles
 
 from database import Data
 
@@ -19,3 +20,6 @@ def post_home(req: str = Body(..., media_type="text/plain")):
     print(f"[Debug] new sentence: {req}")
     data.add(req)
     return {"req": req}
+
+
+app.mount("/", StaticFiles(directory="front", html=True), name="static")


### PR DESCRIPTION
GETとPOSTの処理を一旦書いた
手元のhtmlからfetch()するとPOSTでCORSに引っかかるので、サーバーからhtmlを提供するように更新
localhost:8000/ にアクセスしたらページが見れます

POST、GETで動くデータベース関連の処理がまだ仕様通りじゃなさそうなので、たいおうおねがいしたいです