### PR TITLE
各ログインに hash を発行し、ipと併用してアクセス制限

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -3,11 +3,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>homehome - ことばのギフトを贈りあう</title>
-    <meta name="description" content="homehomeは、毎日1回誰かを褒めたり褒められたりできる心温まるWebサービス。思わず笑顔になる“ほめ言葉”が、あなたの1日を明るくします。" />
-    <meta name="keywords" content="褒め言葉, homehome, ポジティブ, 元気になる, ほめてもらう" />
+    <meta
+      name="description"
+      content="homehomeは、毎日1回誰かを褒めたり褒められたりできる心温まるWebサービス。思わず笑顔になる“ほめ言葉”が、あなたの1日を明るくします。" />
+    <meta
+      name="keywords"
+      content="褒め言葉, homehome, ポジティブ, 元気になる, ほめてもらう" />
     <meta name="author" content="homehome project" />
     <meta property="og:title" content="homehome - ことばのギフトを贈りあう" />
-    <meta property="og:description" content="ちょっとした言葉で、誰かの一日を明るくできる。homehomeは、毎日褒めて褒められる場所です。" />
+    <meta
+      property="og:description"
+      content="ちょっとした言葉で、誰かの一日を明るくできる。homehomeは、毎日褒めて褒められる場所です。" />
     <meta property="og:url" content="https://homehome.help/" />
     <meta property="og:type" content="website" />
     <link rel="canonical" href="https://homehome.help/" />
@@ -68,6 +74,14 @@
         onclick="sendNewHome()">
         褒め言葉を贈る
       </button>
+    </div>
+
+    <div class="modal" id="myModal">
+      <div class="modal-content">
+        <p>
+          エラーが発生しました。<br />しばらく時間をおいて再度お試しください。
+        </p>
+      </div>
     </div>
 
     <script src="script.js" type="module"></script>

--- a/front/script.js
+++ b/front/script.js
@@ -129,14 +129,18 @@ const showFallingText = (text) => {
 
 // メイン処理 //
 const beforeLoad = async () => {
-  const receivedHome = await apiFetch("/homes/received");
-  if (receivedHome) {
-    // 取得済み画面を表示
-    setReceivedView(receivedHome);
-  } else {
-    // 褒め言葉を取得してセット
-    elems.initial.innerText = "> ほめてもらう <";
+  const loginHash = localStorage.getItem("login_hash");
+  if (loginHash) {
+    // ログイン履歴がある
+    const receivedHome =  await apiFetch(`/homes/received?hash=${loginHash}`);
+    if (receivedHome) {
+      // 今日のログイン履歴がある：今日の褒め言葉を表示
+      setReceivedView(receivedHome);
+      return;
+    }
   }
+  // 今日の初回ログイン：褒め言葉を取得してセット
+  elems.initial.innerText = "> ほめてもらう <";
 };
 
 // 褒め言葉を表示

--- a/front/script.js
+++ b/front/script.js
@@ -11,6 +11,7 @@ const elems = {
   form: document.getElementById("homeFormContainer"),
   sendBtn: document.getElementById("sendHomeButton"),
   input: document.getElementById("homeInput"),
+  modal: document.getElementById("myModal"),
 };
 
 // API ラッパー
@@ -132,7 +133,7 @@ const beforeLoad = async () => {
   const loginHash = localStorage.getItem("login_hash");
   if (loginHash) {
     // ログイン履歴がある
-    const receivedHome =  await apiFetch(`/homes/received?hash=${loginHash}`);
+    const receivedHome = await apiFetch(`/homes/received?hash=${loginHash}`);
     if (receivedHome) {
       // 今日のログイン履歴がある：今日の褒め言葉を表示
       setReceivedView(receivedHome);
@@ -145,14 +146,19 @@ const beforeLoad = async () => {
 
 // 褒め言葉を表示
 const showHome = async () => {
-  const home = await apiFetch("/homes")
-  elems.message.innerText = home.sentence;
-  // ログイン情報を保存
-  localStorage.setItem("login_hash", home.hash);
-  // 効果音
-  playSound("get");
-  // 初期画面 -> 褒め言葉表示画面 に遷移
-  transitionToHomeView();
+  try {
+    const home = await apiFetch("/homes");
+    elems.message.innerText = home.sentence;
+    // ログイン情報を保存
+    localStorage.setItem("login_hash", home.hash);
+    // 効果音
+    playSound("get");
+    // 初期画面 -> 褒め言葉表示画面 に遷移
+    transitionToHomeView();
+  } catch (error) {
+    // エラーモーダルを表示
+    elems.modal.classList.add("active");
+  }
 };
 
 // 褒めフォームを表示

--- a/front/script.js
+++ b/front/script.js
@@ -141,7 +141,10 @@ const beforeLoad = async () => {
 
 // 褒め言葉を表示
 const showHome = async () => {
-  elems.message.innerText = (await apiFetch("/homes")).sentence;
+  const home = await apiFetch("/homes")
+  elems.message.innerText = home.sentence;
+  // ログイン情報を保存
+  localStorage.setItem("login_hash", home.hash);
   // 効果音
   playSound("get");
   // 初期画面 -> 褒め言葉表示画面 に遷移

--- a/front/script.js
+++ b/front/script.js
@@ -181,9 +181,10 @@ const sendNewHome = async () => {
   }
 
   // 褒め言葉をPOST
+  const loginHash = localStorage.getItem("login_hash");
   await apiFetch("/homes", {
     method: "POST",
-    body: JSON.stringify({ sentence: newSentence }),
+    body: JSON.stringify({ sentence: newSentence, hash: loginHash }),
   });
 
   // 効果音

--- a/front/script.js
+++ b/front/script.js
@@ -25,16 +25,6 @@ const apiFetch = async (endpoint, options = {}) => {
   return response.json();
 };
 
-const getHome = async () => {
-  // 褒め言葉を取得済みならそれを、そうでなければ新規取得して返す
-  const receivedHome = await apiFetch("/homes/received");
-  if (receivedHome) {
-    return receivedHome.sentence;
-  } else {
-    return await apiFetch("/homes").sentence;
-  }
-};
-
 // 文字数制限関係
 const MAX_LENGTH = 20;
 

--- a/front/style.css
+++ b/front/style.css
@@ -396,3 +396,36 @@ canvas {
   text-align: center;
   font-family: "Zen Kurenaido", sans-serif;
 }
+
+/* モーダルの背景 */
+.modal {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5); /* 半透明の背景 */
+  display: flex;
+  align-items: center; /* 縦方向の中央揃え */
+  justify-content: center; /* 横方向の中央揃え */
+  z-index: 1000;
+}
+
+/* モーダルの中身 */
+.modal-content {
+  background: rgb(255, 0, 0);
+  color: #ffffff;
+  padding: 2rem;
+  border-radius: 8px;
+  max-width: 400px;
+  text-align: center;
+}
+
+.modal.active {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+}

--- a/main.py
+++ b/main.py
@@ -43,7 +43,10 @@ def get_home(req: Request):
         return JSONResponse(content={"sentence": home.sentence, "hash": new_hash})
 
     else:
-        return JSONResponse(content={"sentence": home.sentence})
+        return JSONResponse(
+            content={"detail": "同一IPからの今日のリクエストが上限に達しました。"},
+            status_code=403,
+        )
 
 
 # ほめ言葉を一つ追加する

--- a/main.py
+++ b/main.py
@@ -34,12 +34,15 @@ def get_home(req: Request):
     client_host = req.client.host
 
     home = home_service.find_random_one()
+    login_record = login_record_service.find_by_ip(client_host)
     # この時点で login_record が無ければ作成
-    if not login_record_service.find_by_ip(client_host):
+    if not login_record:
         # LoginRecord を作成し、ハッシュを取得
         new_hash = login_record_service.create(ip=client_host, home_id=home.id)
+        return JSONResponse(content={"sentence": home.sentence, "hash": new_hash})
 
-    return JSONResponse(content={"sentence": home.sentence, "hash": new_hash})
+    else:
+        return JSONResponse(content={"sentence": home.sentence})
 
 
 # ほめ言葉を一つ追加する
@@ -62,11 +65,10 @@ def post_home(req: Request, body: PostHomeRequest):
     )
 
 
-# 受け取り済みの home があれば返す
+# 受け取り済みの home があれば返す（hash はクエリパラメータ）
 @app.get("/homes/received")
-def received(req: Request):
-    client_host = req.client.host
-    received = login_record_service.received(client_host)
+def received(hash: str):
+    received = login_record_service.received(hash)
     if received:
         return JSONResponse(content=asdict(received))
 

--- a/main.py
+++ b/main.py
@@ -36,9 +36,10 @@ def get_home(req: Request):
     home = home_service.find_random_one()
     # この時点で login_record が無ければ作成
     if not login_record_service.find_by_ip(client_host):
-        login_record_service.create(ip=client_host, home_id=home.id)
+        # LoginRecord を作成し、ハッシュを取得
+        new_hash = login_record_service.create(ip=client_host, home_id=home.id)
 
-    return JSONResponse(content={"sentence": home.sentence})
+    return JSONResponse(content={"sentence": home.sentence, "hash": new_hash})
 
 
 # ほめ言葉を一つ追加する

--- a/model/login_record.py
+++ b/model/login_record.py
@@ -5,6 +5,7 @@ from .base_model import BaseModel
 
 @dataclass
 class LoginRecord(BaseModel):
+    hash: str
     ip: str
     home_id: int
     has_posted: bool

--- a/service/login_record_service.py
+++ b/service/login_record_service.py
@@ -43,9 +43,17 @@ class LoginRecordService(DataService):
         else:
             return None
 
-    def received(self, ip: str) -> Home:
+    def find_by_hash(self, hash: str) -> LoginRecord | None:
+        # ip が既に登録されているか
+        login_records = self.dao.find_by_column("hash", hash)
+        if login_records:
+            return login_records[0]
+        else:
+            return None
+
+    def received(self, hash: str) -> Home:
         # 受け取り済みの褒め言葉があれば返す
-        login_record = self.find_by_ip(ip)
+        login_record = self.find_by_hash(hash)
         if login_record:
             received_home = home_dao.find_by_column("id", login_record.home_id)[0]
             return received_home

--- a/service/login_record_service.py
+++ b/service/login_record_service.py
@@ -29,19 +29,15 @@ class LoginRecordService(DataService):
         return new_hash
 
     def update(self, login_record: LoginRecord):
-        self.dao.update_row(login_record, key_column="ip")
+        self.dao.update_row(login_record, key_column="hash")
 
     def update_has_posted(self, login_record: LoginRecord):
         login_record.has_posted = True
         self.update(login_record)
 
-    def find_by_ip(self, ip: str) -> LoginRecord | None:
+    def find_by_ip(self, ip: str) -> list[LoginRecord]:
         # ip が既に登録されているか
-        login_records = self.dao.find_by_column("ip", ip)
-        if login_records:
-            return login_records
-        else:
-            return None
+        return self.dao.find_by_column("ip", ip)
 
     def find_by_hash(self, hash: str) -> LoginRecord | None:
         # ip が既に登録されているか

--- a/service/login_record_service.py
+++ b/service/login_record_service.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 
 from dao import CsvDao, home_dao
 from model import Home, LoginRecord
@@ -13,6 +14,7 @@ class LoginRecordService(DataService):
     def create(self, ip: str, home_id: str):
         login_record = LoginRecord.from_dict(
             {
+                "hash": str(uuid.uuid4()),
                 "ip": ip,
                 "home_id": home_id,
                 "has_posted": False,

--- a/service/login_record_service.py
+++ b/service/login_record_service.py
@@ -11,10 +11,14 @@ class LoginRecordService(DataService):
         super().__init__()
         self.dao = dao
 
-    def create(self, ip: str, home_id: str):
+    def create(self, ip: str, home_id: str) -> str:
+        """
+        LoginRecord を作成し、発行したハッシュを返す
+        """
+        new_hash = str(uuid.uuid4())
         login_record = LoginRecord.from_dict(
             {
-                "hash": str(uuid.uuid4()),
+                "hash": new_hash,
                 "ip": ip,
                 "home_id": home_id,
                 "has_posted": False,
@@ -22,6 +26,7 @@ class LoginRecordService(DataService):
             }
         )
         self.dao.add_row(login_record)
+        return new_hash
 
     def update(self, login_record: LoginRecord):
         self.dao.update_row(login_record, key_column="ip")

--- a/service/login_record_service.py
+++ b/service/login_record_service.py
@@ -39,7 +39,7 @@ class LoginRecordService(DataService):
         # ip が既に登録されているか
         login_records = self.dao.find_by_column("ip", ip)
         if login_records:
-            return login_records[0]
+            return login_records
         else:
             return None
 

--- a/test/reset_db.sh
+++ b/test/reset_db.sh
@@ -4,4 +4,4 @@ touch db/homes.csv
 touch db/login_records.csv
 echo "id,sentence,is_used,created_at" >> db/homes.csv
 echo "1,すごいね！,False,2025-04-07 11:20:30" >> db/homes.csv
-echo "ip,home_id,created_at,has_posted" >> db/login_records.csv
+echo "hash,ip,home_id,created_at,has_posted" >> db/login_records.csv


### PR DESCRIPTION
Closes: #77 

# 概要
LoginRecordに hash というカラムを追加し、ipに代わって主キーとした。
hash を使って初回ログインの判定を行い、ip は hash の発行制限に使う。

- 初回ログイン
GET /homes と同時にLoginRecordが発行され、Responseからhashを取得して、LocalStorageに保存する

- 二回目以降ログイン
サイト読み込み直後の GET /homes/received に、LocalStorageに保存された hash を送信して、
  - 今日有効な hash がある -> 受取済みの今日のHomeを返す
  - hash の期限が切れている（LoginRecordが見つからなかった） -> 初回ログインとして扱う

# 話し合いたい
今は一旦同じIPで10個まで hash を発行できるようにしたけど、上限に到達した場合はどんな画面を出そう？
-> 見通しが立つまでこのPRはDraftにしてます