### PR TITLE
サイトロード時の軽量化をした

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,7 @@ services:
             - ./nginx/conf.d:/etc/nginx/conf.d
             - ./nginx/certbot/www:/var/www/certbot
             - ./nginx/certbot/conf:/etc/letsencrypt
-            - ./front/assets:/usr/share/nginx/html/assets
+            - ./front:/usr/share/nginx/html
         depends_on:
             - app
     certbot:

--- a/front/index.html
+++ b/front/index.html
@@ -12,12 +12,11 @@
     <meta property="og:type" content="website" />
     <link rel="canonical" href="https://homehome.help/" />
     <link rel="stylesheet" href="style.css" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Zen+Kurenaido&display=swap"
-      rel="stylesheet" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap"
-      rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Zen+Kurenaido&display=swap" />
+    <link href="https://fonts.googleapis.com/css2?family=Zen+Kurenaido&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" />
+    <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
     <link rel="icon" href="/assets/icons/favicon.ico" />
   </head>
   <body onclick="showHome()">
@@ -72,6 +71,6 @@
 
     <script src="script.js" type="module"></script>
     <script src="config.js"></script>
-    <audio id="se" preload="auto"></audio>
+    <audio id="se" preload="none"></audio>
   </body>
 </html>

--- a/front/index.html
+++ b/front/index.html
@@ -71,6 +71,6 @@
 
     <script src="script.js" type="module"></script>
     <script src="config.js"></script>
-    <audio id="se" preload="none"></audio>
+    <audio id="se" preload="auto"></audio>
   </body>
 </html>

--- a/front/script.js
+++ b/front/script.js
@@ -194,4 +194,4 @@ window.sendNewHome = sendNewHome;
 
 // 初期化
 await beforeLoad();
-startParticles();
+setTimeout(() => startParticles(), 3000); // 3秒後にパーティクルを開始

--- a/front/script.js
+++ b/front/script.js
@@ -194,4 +194,4 @@ window.sendNewHome = sendNewHome;
 
 // 初期化
 await beforeLoad();
-setTimeout(() => startParticles(), 3000); // 3秒後にパーティクルを開始
+startParticles();

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,4 +1,5 @@
 limit_req_zone $binary_remote_addr zone=homehome_zone:10m rate=20r/m;
+limit_req_zone $binary_remote_addr zone=config_zone:1m rate=10r/m; # for config.js
 
 server {
     listen 443 ssl;
@@ -13,17 +14,30 @@ server {
     gzip on;
     gzip_types application/javascript text/css text/html;
 
+    # Static files (and cache)
     location /assets/ {
         root /usr/share/nginx/html;
         expires 30d;
         add_header Cache-Control "public";
     }
 
+    # Static files
     location ~* \.(js|css|woff2) {
         root /usr/share/nginx/html;
         add_header Cache-Control "no-store";
     }
 
+    # config.js
+    location = /config.js {
+        limit_req zone=config_zone burst=5 nodelay;
+        proxy_pass http://app:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # API
     location / {
         limit_req zone=homehome_zone burst=5;
         proxy_pass http://app:8000;

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -10,6 +10,9 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
 
+    gzip on;
+    gzip_types application/javascript text/css text/html;
+
     location /assets/ {
         root /usr/share/nginx/html;
         expires 30d;

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -19,6 +19,11 @@ server {
         add_header Cache-Control "public";
     }
 
+    location ~* \.(js|css|woff2) {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "no-store";
+    }
+
     location / {
         limit_req zone=homehome_zone burst=5;
         proxy_pass http://app:8000;

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -39,7 +39,7 @@ server {
 
     # API
     location / {
-        limit_req zone=homehome_zone burst=5;
+        limit_req zone=homehome_zone burst=5 nodelay;
         proxy_pass http://app:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
# 経緯
しばらくの間、本番環境で実行をしてこなかったがサーバーを立ててアクセスしてみたところ、「ほめてもらう」の文字が出るまでに十数秒かかってしまうという、問題が発生していた。
そこで、Issues #74 を建て調査をして今に至る。
# 解決
結論を言うと、nginxでDos攻撃対策用のPR #57 での変更で追加したlimit_reqの制限にすべてのリクエストが含まれてしまっていることが根本的な原因であった。
そこで、静的ファイル（index.html以外）を全てnginx自体で返して、それらをlimit_reqの制限にかからないように設定したところ上手く動いた。
# やってないこと
- ファイルのminify化やバンドル化をしていない。（この程度のデータ量なら問題ないと思うため飛ばした）
- サイトの処理自体の軽量化はしていない。パーティクル処理等で肝心なアニメーションがカクついてしまう場合がある。
- サイトのロード時間が十数秒から450ms程度になったが、依然として遅い。→ ロード画面の作成をするべきだと思う。
- API用のパス等を/api/〇〇などに変更をしていない（話し合いたい）

nginx詳しくないので、もしかしたら見逃してる設定があるかも！